### PR TITLE
Editable install in CI to make codecov work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
         run: conda install pytest-cov
 
       - name: Install AlgoPytest
-        run: pip install .
+        # Editable install so that pytest code coverage can find the local library files
+        run: pip install -e .
           
       - name: List conda information
         run: |


### PR DESCRIPTION
PyTest code coverage would use the system installation of `algopytest` instead of the local one. That meant that the local `algopytest` would get 0 hits and falsely report a 0% code coverage report.