### PR TITLE
Interactive mode for the 'spellcheck.sh' script

### DIFF
--- a/.spellcheck.sh
+++ b/.spellcheck.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
 # Spellchecker docs: https://github.com/myint/scspell
-scspell $@ --use-builtin-base-dict --override-dictionary ./.dict --relative-to $(pwd) --report-only
-
-# TODO! Make this work
-#if [ $1 == "interactive" ]; then
-#    scspell $@ --use-builtin-base-dict --override-dictionary ./.dict --relative-to $(pwd) --report-only
-#else
-#    scspell $2 --use-builtin-base-dict --override-dictionary ./.dict --relative-to $(pwd)
-#fi
+if [ $1 != "interactive" ]; then
+    scspell $@ --use-builtin-base-dict --override-dictionary ./.dict --relative-to $(pwd) --report-only
+else
+    scspell $2 --use-builtin-base-dict --override-dictionary ./.dict --relative-to $(pwd)
+fi


### PR DESCRIPTION
This is useful for when the spellchecker step of the pre-commit fails and you'd like to add new words to the dictionary files manually. Invoking the spellchecker script in interactive mode gives you that opportunity.