### PR TITLE
Fill in all arguments to `transaction_ops`, including less used ones 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ straightforward as possible.
 - Function ``group_transaction`` to send group transactions
 - Removed ``ProgramStore`` class and replaced it with ``deploy_smart_contract`` which the user would call directly in a user-defined fixture to retrieve the smart contract app ID for testing
 - Implemented support for group transactions to hold both ``Transaction`` and ``LogicSigTransaction``
+- All transaction operations take all possible parameters, even the less commonly used ones.
 
 ### Bug Fixes
 - Removed typing subscripts to be compatible with Python 3.8

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -260,7 +260,14 @@ def update_app(
     app_id: int,
     approval_compiled: bytes,
     clear_compiled: bytes,
-    params: Optional[transaction.SuggestedParams],
+    *params: Optional[transaction.SuggestedParams],
+    app_args: Optional[list[str]] = None,
+    accounts: Optional[list[str]] = None,
+    foreign_apps: Optional[list[int]] = None,
+    foreign_assets: Optional[list[int]] = None,
+    note: str = "",
+    lease: str = "",
+    rekey_to: str = "",
 ) -> Tuple[AlgoUser, transaction.Transaction]:
     """Update a deployed smart contract.
 
@@ -276,13 +283,45 @@ def update_app(
         The TEAL compiled binary code of the clear program.
     params
         Transaction parameters to use when sending the ``ApplicationUpdateTxn`` into the Algorand network.
+    app_args
+        Any additional arguments to the application.
+    accounts
+        Any additional accounts to supply to the application.
+    foreign_apps
+        Any other apps used by the application, identified by app index.
+    foreign_assets
+        List of assets involved in call.
+    note
+        A note to attach to the application creation transaction.
+    lease
+        A unique lease where no other transaction from the same sender and same lease
+        can be confirmed during the transactions valid rounds.
+    rekey_to
+        An Algorand address to rekey the sender to.
 
     Returns
     -------
     None
     """
+    # Materialize all of the optional arguments
+    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    accounts = accounts or []
+    foreign_apps = foreign_apps or []
+    foreign_assets = foreign_assets or []
+
     txn = transaction.ApplicationUpdateTxn(
-        owner.address, params, app_id, approval_compiled, clear_compiled
+        owner.address,
+        params,
+        app_id,
+        approval_compiled,
+        clear_compiled,
+        app_args=app_args_bytes,
+        accounts=accounts,
+        foreign_apps=foreign_apps,
+        foreign_assets=foreign_assets,
+        note=note.encode(),
+        lease=lease.encode(),
+        rekey_to=rekey_to,
     )
 
     return owner, txn

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -335,8 +335,8 @@ def update_app(
 def opt_in_app(
     sender: AlgoUser,
     app_id: int,
-    params: Optional[transaction.SuggestedParams],
     *,
+    params: Optional[transaction.SuggestedParams],
     app_args: Optional[list[str]] = None,
     accounts: Optional[list[str]] = None,
     foreign_apps: Optional[list[int]] = None,
@@ -401,7 +401,17 @@ def opt_in_app(
     format_finish=lambda txninfo: f'app-id={txninfo["txn"]["txn"]["apid"]}',
 )
 def close_out_app(
-    sender: AlgoUser, app_id: int, params: Optional[transaction.SuggestedParams]
+    sender: AlgoUser,
+    app_id: int,
+    *,
+    params: Optional[transaction.SuggestedParams],
+    app_args: Optional[list[str]] = None,
+    accounts: Optional[list[str]] = None,
+    foreign_apps: Optional[list[int]] = None,
+    foreign_assets: Optional[list[int]] = None,
+    note: str = "",
+    lease: str = "",
+    rekey_to: str = "",
 ) -> Tuple[AlgoUser, transaction.Transaction]:
     """Close-out from a deployed smart contract.
 
@@ -413,12 +423,44 @@ def close_out_app(
         The application ID of the deployed smart contract.
     params
         Transaction parameters to use when sending the ``ApplicationCloseOutTxn`` into the Algorand network.
+    app_args
+        Any additional arguments to the application.
+    accounts
+        Any additional accounts to supply to the application.
+    foreign_apps
+        Any other apps used by the application, identified by app index.
+    foreign_assets
+        List of assets involved in call.
+    note
+        A note to attach to the application creation transaction.
+    lease
+        A unique lease where no other transaction from the same sender and same lease
+        can be confirmed during the transactions valid rounds.
+    rekey_to
+        An Algorand address to rekey the sender to.
 
     Returns
     -------
     None
     """
-    txn = transaction.ApplicationCloseOutTxn(sender.address, params, app_id)
+    # Materialize all of the optional arguments
+    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    accounts = accounts or []
+    foreign_apps = foreign_apps or []
+    foreign_assets = foreign_assets or []
+
+    txn = transaction.ApplicationCloseOutTxn(
+        sender.address,
+        params,
+        app_id,
+        app_args=app_args_bytes,
+        accounts=accounts,
+        foreign_apps=foreign_apps,
+        foreign_assets=foreign_assets,
+        note=note.encode(),
+        lease=lease.encode(),
+        rekey_to=rekey_to,
+    )
     return sender, txn
 
 
@@ -427,7 +469,17 @@ def close_out_app(
     format_finish=lambda txninfo: f'app-id={txninfo["txn"]["txn"]["apid"]}',
 )
 def clear_app(
-    sender: AlgoUser, app_id: int, params: Optional[transaction.SuggestedParams]
+    sender: AlgoUser,
+    app_id: int,
+    *,
+    params: Optional[transaction.SuggestedParams],
+    app_args: Optional[list[str]] = None,
+    accounts: Optional[list[str]] = None,
+    foreign_apps: Optional[list[int]] = None,
+    foreign_assets: Optional[list[int]] = None,
+    note: str = "",
+    lease: str = "",
+    rekey_to: str = "",
 ) -> Tuple[AlgoUser, transaction.Transaction]:
     """Clear from a deployed smart contract.
 
@@ -439,12 +491,44 @@ def clear_app(
         The application ID of the deployed smart contract.
     params
         Transaction parameters to use when sending the ``ApplicationClearStateTxn`` into the Algorand network.
+    app_args
+        Any additional arguments to the application.
+    accounts
+        Any additional accounts to supply to the application.
+    foreign_apps
+        Any other apps used by the application, identified by app index.
+    foreign_assets
+        List of assets involved in call.
+    note
+        A note to attach to the application creation transaction.
+    lease
+        A unique lease where no other transaction from the same sender and same lease
+        can be confirmed during the transactions valid rounds.
+    rekey_to
+        An Algorand address to rekey the sender to.
 
     Returns
     -------
     None
     """
-    txn = transaction.ApplicationClearStateTxn(sender.address, params, app_id)
+    # Materialize all of the optional arguments
+    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    accounts = accounts or []
+    foreign_apps = foreign_apps or []
+    foreign_assets = foreign_assets or []
+
+    txn = transaction.ApplicationClearStateTxn(
+        sender.address,
+        params,
+        app_id,
+        app_args=app_args_bytes,
+        accounts=accounts,
+        foreign_apps=foreign_apps,
+        foreign_assets=foreign_assets,
+        note=note.encode(),
+        lease=lease.encode(),
+        rekey_to=rekey_to,
+    )
     return sender, txn
 
 
@@ -455,9 +539,15 @@ def clear_app(
 def call_app(
     sender: AlgoUser,
     app_id: int,
+    *,
     params: Optional[transaction.SuggestedParams],
     app_args: Optional[List[str]] = None,
     accounts: Optional[List[str]] = None,
+    foreign_apps: Optional[list[int]] = None,
+    foreign_assets: Optional[list[int]] = None,
+    note: str = "",
+    lease: str = "",
+    rekey_to: str = "",
 ) -> Tuple[AlgoUser, transaction.Transaction]:
     """Perform an application call to a deployed smart contract.
 
@@ -473,17 +563,39 @@ def call_app(
         Any arguments to pass along with the application call.
     accounts
         Any Algorand account addresses to pass along with the application call.
+    foreign_apps
+        Any other apps used by the application, identified by app index.
+    foreign_assets
+        List of assets involved in call.
+    note
+        A note to attach to the application creation transaction.
+    lease
+        A unique lease where no other transaction from the same sender and same lease
+        can be confirmed during the transactions valid rounds.
+    rekey_to
+        An Algorand address to rekey the sender to.
 
     Returns
     -------
     None
     """
+    # Materialize all of the optional arguments
+    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    accounts = accounts or []
+    foreign_apps = foreign_apps or []
+    foreign_assets = foreign_assets or []
+
     txn = transaction.ApplicationNoOpTxn(
         sender.address,
         params,
         app_id,
-        app_args,
-        accounts,
+        app_args=app_args_bytes,
+        accounts=accounts,
+        foreign_apps=foreign_apps,
+        foreign_assets=foreign_assets,
+        note=note.encode(),
+        lease=lease.encode(),
+        rekey_to=rekey_to,
     )
     return sender, txn
 
@@ -549,6 +661,7 @@ def payment_transaction(
 def smart_signature_transaction(
     smart_signature: bytes,
     txn: transaction.Transaction,
+    *,
     params: Optional[transaction.SuggestedParams],
 ) -> Tuple[AlgoUser, transaction.Transaction]:
     """Write docs here: TODO!"""

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -188,7 +188,17 @@ def create_app(
     format_finish=lambda txninfo: f'app-id={txninfo["txn"]["txn"]["apid"]}',
 )
 def delete_app(
-    owner: AlgoUser, app_id: int, params: Optional[transaction.SuggestedParams]
+    owner: AlgoUser,
+    app_id: int,
+    *,
+    params: Optional[transaction.SuggestedParams],
+    app_args: Optional[list[str]] = None,
+    accounts: Optional[list[str]] = None,
+    foreign_apps: Optional[list[int]] = None,
+    foreign_assets: Optional[list[int]] = None,
+    note: str = "",
+    lease: str = "",
+    rekey_to: str = "",
 ) -> Tuple[AlgoUser, transaction.Transaction]:
     """Delete a deployed smart contract.
 
@@ -200,12 +210,44 @@ def delete_app(
         The application ID of the deployed smart contract.
     params
         Transaction parameters to use when sending the ``ApplicationDeleteTxn`` into the Algorand network.
+    app_args
+        Any additional arguments to the application.
+    accounts
+        Any additional accounts to supply to the application.
+    foreign_apps
+        Any other apps used by the application, identified by app index.
+    foreign_assets
+        List of assets involved in call.
+    note
+        A note to attach to the application creation transaction.
+    lease
+        A unique lease where no other transaction from the same sender and same lease
+        can be confirmed during the transactions valid rounds.
+    rekey_to
+        An Algorand address to rekey the sender to.
 
     Returns
     -------
     None
     """
-    txn = transaction.ApplicationDeleteTxn(owner.address, params, app_id)
+    # Materialize all of the optional arguments
+    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    accounts = accounts or []
+    foreign_apps = foreign_apps or []
+    foreign_assets = foreign_assets or []
+
+    txn = transaction.ApplicationDeleteTxn(
+        owner.address,
+        params,
+        app_id,
+        app_args=app_args_bytes,
+        accounts=accounts,
+        foreign_apps=foreign_apps,
+        foreign_assets=foreign_assets,
+        note=note.encode(),
+        lease=lease.encode(),
+        rekey_to=rekey_to,
+    )
     return owner, txn
 
 

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -103,10 +103,10 @@ def create_app(
     local_schema: transaction.StateSchema,
     *,
     params: Optional[transaction.SuggestedParams],
-    app_args: Optional[list[str]] = None,
-    accounts: Optional[list[str]] = None,
-    foreign_apps: Optional[list[int]] = None,
-    foreign_assets: Optional[list[int]] = None,
+    app_args: Optional[List[Union[str, int]]] = None,
+    accounts: Optional[List[str]] = None,
+    foreign_apps: Optional[List[int]] = None,
+    foreign_assets: Optional[List[int]] = None,
     note: str = "",
     lease: str = "",
     rekey_to: str = "",
@@ -152,7 +152,7 @@ def create_app(
         The application ID of the deployed smart contract.
     """
     # Materialize all of the optional arguments
-    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    app_args = app_args or []
     accounts = accounts or []
     foreign_apps = foreign_apps or []
     foreign_assets = foreign_assets or []
@@ -169,7 +169,7 @@ def create_app(
         clear_compiled,
         global_schema,
         local_schema,
-        app_args=app_args_bytes,
+        app_args=app_args,
         accounts=accounts,
         foreign_apps=foreign_apps,
         foreign_assets=foreign_assets,
@@ -191,10 +191,10 @@ def delete_app(
     app_id: int,
     *,
     params: Optional[transaction.SuggestedParams],
-    app_args: Optional[list[str]] = None,
-    accounts: Optional[list[str]] = None,
-    foreign_apps: Optional[list[int]] = None,
-    foreign_assets: Optional[list[int]] = None,
+    app_args: Optional[List[Union[str, int]]] = None,
+    accounts: Optional[List[str]] = None,
+    foreign_apps: Optional[List[int]] = None,
+    foreign_assets: Optional[List[int]] = None,
     note: str = "",
     lease: str = "",
     rekey_to: str = "",
@@ -230,7 +230,7 @@ def delete_app(
     None
     """
     # Materialize all of the optional arguments
-    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    app_args = app_args or []
     accounts = accounts or []
     foreign_apps = foreign_apps or []
     foreign_assets = foreign_assets or []
@@ -239,7 +239,7 @@ def delete_app(
         owner.address,
         params,
         app_id,
-        app_args=app_args_bytes,
+        app_args=app_args,
         accounts=accounts,
         foreign_apps=foreign_apps,
         foreign_assets=foreign_assets,
@@ -261,10 +261,10 @@ def update_app(
     clear_compiled: bytes,
     *,
     params: Optional[transaction.SuggestedParams],
-    app_args: Optional[list[str]] = None,
-    accounts: Optional[list[str]] = None,
-    foreign_apps: Optional[list[int]] = None,
-    foreign_assets: Optional[list[int]] = None,
+    app_args: Optional[List[Union[str, int]]] = None,
+    accounts: Optional[List[str]] = None,
+    foreign_apps: Optional[List[int]] = None,
+    foreign_assets: Optional[List[int]] = None,
     note: str = "",
     lease: str = "",
     rekey_to: str = "",
@@ -304,7 +304,7 @@ def update_app(
     None
     """
     # Materialize all of the optional arguments
-    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    app_args = app_args or []
     accounts = accounts or []
     foreign_apps = foreign_apps or []
     foreign_assets = foreign_assets or []
@@ -315,7 +315,7 @@ def update_app(
         app_id,
         approval_compiled,
         clear_compiled,
-        app_args=app_args_bytes,
+        app_args=app_args,
         accounts=accounts,
         foreign_apps=foreign_apps,
         foreign_assets=foreign_assets,
@@ -336,10 +336,10 @@ def opt_in_app(
     app_id: int,
     *,
     params: Optional[transaction.SuggestedParams],
-    app_args: Optional[list[str]] = None,
-    accounts: Optional[list[str]] = None,
-    foreign_apps: Optional[list[int]] = None,
-    foreign_assets: Optional[list[int]] = None,
+    app_args: Optional[List[Union[str, int]]] = None,
+    accounts: Optional[List[str]] = None,
+    foreign_apps: Optional[List[int]] = None,
+    foreign_assets: Optional[List[int]] = None,
     note: str = "",
     lease: str = "",
     rekey_to: str = "",
@@ -375,7 +375,7 @@ def opt_in_app(
     None
     """
     # Materialize all of the optional arguments
-    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    app_args = app_args or []
     accounts = accounts or []
     foreign_apps = foreign_apps or []
     foreign_assets = foreign_assets or []
@@ -384,7 +384,7 @@ def opt_in_app(
         sender.address,
         params,
         app_id,
-        app_args=app_args_bytes,
+        app_args=app_args,
         accounts=accounts,
         foreign_apps=foreign_apps,
         foreign_assets=foreign_assets,
@@ -404,10 +404,10 @@ def close_out_app(
     app_id: int,
     *,
     params: Optional[transaction.SuggestedParams],
-    app_args: Optional[list[str]] = None,
-    accounts: Optional[list[str]] = None,
-    foreign_apps: Optional[list[int]] = None,
-    foreign_assets: Optional[list[int]] = None,
+    app_args: Optional[List[Union[str, int]]] = None,
+    accounts: Optional[List[str]] = None,
+    foreign_apps: Optional[List[int]] = None,
+    foreign_assets: Optional[List[int]] = None,
     note: str = "",
     lease: str = "",
     rekey_to: str = "",
@@ -443,7 +443,7 @@ def close_out_app(
     None
     """
     # Materialize all of the optional arguments
-    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    app_args = app_args or []
     accounts = accounts or []
     foreign_apps = foreign_apps or []
     foreign_assets = foreign_assets or []
@@ -452,7 +452,7 @@ def close_out_app(
         sender.address,
         params,
         app_id,
-        app_args=app_args_bytes,
+        app_args=app_args,
         accounts=accounts,
         foreign_apps=foreign_apps,
         foreign_assets=foreign_assets,
@@ -472,10 +472,10 @@ def clear_app(
     app_id: int,
     *,
     params: Optional[transaction.SuggestedParams],
-    app_args: Optional[list[str]] = None,
-    accounts: Optional[list[str]] = None,
-    foreign_apps: Optional[list[int]] = None,
-    foreign_assets: Optional[list[int]] = None,
+    app_args: Optional[List[Union[str, int]]] = None,
+    accounts: Optional[List[str]] = None,
+    foreign_apps: Optional[List[int]] = None,
+    foreign_assets: Optional[List[int]] = None,
     note: str = "",
     lease: str = "",
     rekey_to: str = "",
@@ -511,7 +511,7 @@ def clear_app(
     None
     """
     # Materialize all of the optional arguments
-    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    app_args = app_args or []
     accounts = accounts or []
     foreign_apps = foreign_apps or []
     foreign_assets = foreign_assets or []
@@ -520,7 +520,7 @@ def clear_app(
         sender.address,
         params,
         app_id,
-        app_args=app_args_bytes,
+        app_args=app_args,
         accounts=accounts,
         foreign_apps=foreign_apps,
         foreign_assets=foreign_assets,
@@ -540,10 +540,10 @@ def call_app(
     app_id: int,
     *,
     params: Optional[transaction.SuggestedParams],
-    app_args: Optional[List[str]] = None,
+    app_args: Optional[List[Union[str, int]]] = None,
     accounts: Optional[List[str]] = None,
-    foreign_apps: Optional[list[int]] = None,
-    foreign_assets: Optional[list[int]] = None,
+    foreign_apps: Optional[List[int]] = None,
+    foreign_assets: Optional[List[int]] = None,
     note: str = "",
     lease: str = "",
     rekey_to: str = "",
@@ -579,7 +579,7 @@ def call_app(
     None
     """
     # Materialize all of the optional arguments
-    app_args_bytes: list[bytes] = [arg.encode() for arg in (app_args or [])]
+    app_args = app_args or []
     accounts = accounts or []
     foreign_apps = foreign_apps or []
     foreign_assets = foreign_assets or []
@@ -588,7 +588,7 @@ def call_app(
         sender.address,
         params,
         app_id,
-        app_args=app_args_bytes,
+        app_args=app_args,
         accounts=accounts,
         foreign_apps=foreign_apps,
         foreign_assets=foreign_assets,


### PR DESCRIPTION
There are a lot of rarely used arguments that can be passed to an `algosdk.transaction.Transaction`. Support them.