### PR TITLE
Implemented `SmartContractAccount` entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ straightforward as possible.
 - Support ASA operations with the following transaction operations ``create_asset``, ``destroy_asset``, ``update_asset``, ``freeze_asset``, ``transfer_asset``, ``opt_in_asset`` and ``close_out_asset``.
 - Implemented asset related utility functions ``asset_balance`` and ``asset_info``.
 - Support multi-signature transaction with the ``multisig_transaction`` transaction operation.
+- Implemented a ``SmartContractAccount`` entity to hold the address of a smart contract as an ``AlgoUser``.
 
 ### Bug Fixes
 - Removed typing subscripts to be compatible with Python 3.8

--- a/algopytest/__init__.py
+++ b/algopytest/__init__.py
@@ -33,7 +33,7 @@ from .client_ops import (
     compile_program,
     suggested_params,
 )
-from .entities import AlgoUser, MultisigAccount
+from .entities import AlgoUser, MultisigAccount, SmartContractAccount
 from .smart_program_ops import deploy_smart_contract
 from .transaction_ops import (
     call_app,
@@ -60,6 +60,8 @@ from .transaction_ops import (
 # The functions to expose for sphinx documentation
 __all__ = [
     "AlgoUser",
+    "SmartContractAccount",
+    "MultisigAccount",
     "deploy_smart_contract",
     "account_balance",
     "asset_balance",

--- a/algopytest/entities.py
+++ b/algopytest/entities.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
+import algosdk
 from algosdk.future import transaction as algosdk_transaction
 
 
@@ -13,6 +14,16 @@ class AlgoUser:
 
 
 NullUser = AlgoUser(address="")
+
+
+class SmartContractAccount(AlgoUser):
+    """An Algorand user subclass representing a smart contract's account address."""
+
+    def __init__(self, app_id: int):
+        smart_contract_address = algosdk.logic.get_application_address(app_id)
+
+        # Instantiate the super `AlgoUser` class
+        super().__init__(address=smart_contract_address)
 
 
 class MultisigAccount(AlgoUser):


### PR DESCRIPTION
This `SmartContractAccount` entity subclasses the `AlgoUser` and is used to store the address of a smart contract's account. 

---

### Checklist

- [X] Added a CHANGELOG entry
- [X] Tested locally
- [ ] Wrote new tests
- [ ] Added new dependencies
- [ ] Updated the documentation