### PR TITLE
Speed up `AlgoPytest` by caching `_initial_funds_account`.

### DIFF
--- a/.dict
+++ b/.dict
@@ -43,6 +43,7 @@ pyteal
 
 FILEID: f4764254-2184-11ed-aa51-e4b318472d90
 ipaleka
+maxsize
 
 FILEID: fb59cdc0-2184-11ed-8e52-e4b318472d90
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ straightforward as possible.
 - Inputs which accept ``PyTEAL`` directly take the ``pyteal.Expr`` and not a function which generates a ``pyteal.Expr``
 - All transaction operations take all possible parameters, even the less commonly used ones.
 - The AlgoPytest API accepts ``AlgoUser`` as a user input anywhere whenever an address is requested.
+- Sped up the ``AlgoPytest`` test suite runtime by caching the ``_initial_funds_account``.
 
 ## [1.0.0] - 2022-02-09
 


### PR DESCRIPTION
Cached the `_initial_funds_account` which improved performance.
Tuned the sleep times in the `@_wait_for_indexer` decorator

Resolves #26 

---

### Checklist

- [x] Added a CHANGELOG entry
- [ ] Tested locally
- [ ] Wrote new tests
- [ ] Added new dependencies
- [ ] Updated the documentation