### PR TITLE
Use KMD to access sandbox private keys

### DIFF
--- a/.dict
+++ b/.dict
@@ -28,9 +28,6 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 FILEID: ada294b6-217c-11ed-9d3f-e4b318472d90
 apid
 
-FILEID: b9d85dc4-217c-11ed-b545-e4b318472d90
-ipaleka
-
 FILEID: b1beb24e-2183-11ed-9deb-e4b318472d90
 algopytest
 bjan
@@ -42,7 +39,7 @@ ndmzjwu
 pyteal
 
 FILEID: f4764254-2184-11ed-aa51-e4b318472d90
-ipaleka
+devrel
 maxsize
 
 FILEID: fb59cdc0-2184-11ed-8e52-e4b318472d90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ straightforward as possible.
 - Implemented asset related utility functions ``asset_balance`` and ``asset_info``.
 - Support multi-signature transaction with the ``multisig_transaction`` transaction operation.
 - Implemented a ``SmartContractAccount`` entity to hold the address of a smart contract as an ``AlgoUser``.
+- Utilize the ``KMD`` to access account private keys of the sandbox.
 
 ### Bug Fixes
 - Removed typing subscripts to be compatible with Python 3.8

--- a/algopytest/client_ops.py
+++ b/algopytest/client_ops.py
@@ -50,7 +50,7 @@ def _get_kmd_account_private_key(address: str) -> str:
             break
 
     if wallet_id is None:
-        raise RuntimeError(f"Wallet not found: {ConfigParams.kmd_wallet_name}")
+        raise ValueError(f"Wallet not found: {ConfigParams.kmd_wallet_name}")
 
     wallet_handle = kmd.init_wallet_handle(wallet_id, ConfigParams.kmd_wallet_password)
 

--- a/algopytest/client_ops.py
+++ b/algopytest/client_ops.py
@@ -1,17 +1,12 @@
 """
 Module containing helper functions for accessing Algorand blockchain.
-
-Inspired from: https://github.com/ipaleka/algorand-contracts-testing/blob/main/helpers.py
 """
 # So that sphinx picks up on the type aliases
 from __future__ import annotations
 
 import base64
-import pty
-import subprocess
 import time
 from functools import lru_cache, wraps
-from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 import pyteal
@@ -19,6 +14,7 @@ from algosdk import mnemonic
 from algosdk.error import IndexerHTTPError
 from algosdk.future import transaction as algosdk_transaction
 from algosdk.future.transaction import LogicSig, PaymentTxn, wait_for_confirmation
+from algosdk.kmd import KMDClient
 from algosdk.v2client import algod, indexer
 from pyteal import Mode, compileTeal
 
@@ -40,36 +36,32 @@ def _indexer_client() -> indexer.IndexerClient:
     )
 
 
-## SANDBOX
-def _cli_passphrase_for_account(address: str) -> str:
+## KMD
+def _get_account_private_key(address: str) -> str:
     """Return passphrase for provided ``address``."""
-    process = call_sandbox_command("goal", "account", "export", "-a", address)
+    # Inspired by https://github.com/algorand-devrel/demo-avm1.1/blob/master/demos/utils/sandbox.py
+    kmd = KMDClient(ConfigParams.kmd_token, ConfigParams.kmd_address)
+    wallets = kmd.list_wallets()
 
-    if process.stderr:
-        raise RuntimeError(process.stderr.decode("utf8"))
+    wallet_id = None
+    for wallet in wallets:
+        if wallet["name"] == ConfigParams.kmd_wallet_name:
+            wallet_id = wallet["id"]
+            break
 
-    passphrase = ""
-    parts = process.stdout.decode("utf8").split('"')
-    if len(parts) > 1:
-        passphrase = parts[1]
-    if passphrase == "":
-        raise ValueError(
-            "Can't retrieve passphrase from the address: %s\noutput: %s"
-            % (address, process.stdout.decode("utf8"))
+    if wallet_id is None:
+        raise RuntimeError(f"Wallet not found: {ConfigParams.kmd_wallet_name}")
+
+    wallet_handle = kmd.init_wallet_handle(wallet_id, ConfigParams.kmd_wallet_password)
+
+    try:
+        private_key = kmd.export_key(
+            wallet_handle, ConfigParams.kmd_wallet_password, address
         )
-    return passphrase
+    finally:
+        kmd.release_wallet_handle(wallet_handle)
 
-
-def _sandbox_executable() -> Path:
-    """Return full path to Algorand's sandbox executable."""
-    return ConfigParams.sandbox_dir / "sandbox"
-
-
-def call_sandbox_command(*args: str) -> subprocess.CompletedProcess:
-    """Call and return sandbox command composed from provided arguments."""
-    return subprocess.run(
-        [_sandbox_executable(), *args], stdin=pty.openpty()[1], capture_output=True
-    )
+    return private_key
 
 
 ## TRANSACTIONS
@@ -161,8 +153,7 @@ def _initial_funds_account() -> AlgoUser:
     if initial_address is None:
         raise RuntimeError("Initial funds account not yet created!")
 
-    passphrase = _cli_passphrase_for_account(initial_address)
-    private_key = mnemonic.to_private_key(passphrase)
+    private_key = _get_account_private_key(initial_address)
 
     # Return an `AlgoUser` of the initial account
     return AlgoUser(initial_address, private_key)

--- a/algopytest/client_ops.py
+++ b/algopytest/client_ops.py
@@ -37,7 +37,7 @@ def _indexer_client() -> indexer.IndexerClient:
 
 
 ## KMD
-def _get_account_private_key(address: str) -> str:
+def _get_kmd_account_private_key(address: str) -> str:
     """Return passphrase for provided ``address``."""
     # Inspired by https://github.com/algorand-devrel/demo-avm1.1/blob/master/demos/utils/sandbox.py
     kmd = KMDClient(ConfigParams.kmd_token, ConfigParams.kmd_address)
@@ -153,7 +153,7 @@ def _initial_funds_account() -> AlgoUser:
     if initial_address is None:
         raise RuntimeError("Initial funds account not yet created!")
 
-    private_key = _get_account_private_key(initial_address)
+    private_key = _get_kmd_account_private_key(initial_address)
 
     # Return an `AlgoUser` of the initial account
     return AlgoUser(initial_address, private_key)

--- a/algopytest/config_params.py
+++ b/algopytest/config_params.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from typing import Optional
 
 
@@ -10,11 +9,14 @@ class _ConfigParams:
     algod_token: str = (
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     )
+
     indexer_address: str = "http://localhost:8980"
     indexer_token: str = ""
 
-    # Assume that the sandbox is the sibling directory of this project
-    sandbox_dir: Path = Path(".").resolve().parent / "sandbox"
+    kmd_address: str = "http://localhost:4002"
+    kmd_token: str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    kmd_wallet_name: str = "unencrypted-default-wallet"
+    kmd_wallet_password: str = ""
 
     initial_funds_account: Optional[str] = None
 
@@ -27,15 +29,15 @@ class _ConfigParams:
         self.algod_token = os.environ.get("ALGOD_TOKEN") or self.algod_token
         self.indexer_address = os.environ.get("INDEXER_ADDRESS") or self.indexer_address
         self.indexer_token = os.environ.get("INDEXER_TOKEN") or self.indexer_token
-
-        # Convert the `SANDBOX_DIR` to a `pathlib.Path` if it exists
-        env_sandbox_dir = os.environ.get("SANDBOX_DIR")
-        if env_sandbox_dir is not None:
-            self.sandbox_dir = Path(env_sandbox_dir)
-
-        env_initial_funds_account = os.environ.get("INITIAL_FUNDS_ACCOUNT")
-        if env_initial_funds_account is not None:
-            self.initial_funds_account = env_initial_funds_account
+        self.kmd_address = os.environ.get("KMD_ADDRESS") or self.kmd_address
+        self.kmd_token = os.environ.get("KMD_TOKEN") or self.kmd_token
+        self.kmd_wallet_name = os.environ.get("KMD_WALLET_NAME") or self.kmd_wallet_name
+        self.kmd_wallet_password = (
+            os.environ.get("KMD_WALLET_PASSWORD") or self.kmd_wallet_password
+        )
+        self.initial_funds_account = (
+            os.environ.get("INITIAL_FUNDS_ACCOUNT") or self.initial_funds_account
+        )
 
         # Convert the `INDEXER_TIMEOUT` to an `int` if it exists
         env_indexer_timeout = os.environ.get("INDEXER_TIMEOUT")


### PR DESCRIPTION
This replaces requiring to create a subprocess call to `sandbox goal account export -a <address>` and parse the output which was slow and flaky.

---

### Checklist

- [X] Added a CHANGELOG entry
- [ ] Tested locally
- [ ] Wrote new tests
- [ ] Added new dependencies
- [ ] Updated the documentation