### PR TITLE
Implemented `name` field for all Algorand user entities

### DIFF
--- a/.dict
+++ b/.dict
@@ -1,7 +1,10 @@
 FILETYPE: Python; .py
 algod
+algopytest
 algosdk
+algouser
 functools
+getfixturevalue
 multisig
 openpty
 pathlib
@@ -68,9 +71,30 @@ setuptools
 FILEID: db18d85e-36b4-11ed-a600-e4b318472d90
 multisig
 
+FILEID: 13ba44e0-4a6f-11ed-9e9b-e4b318472d90
+bpvgq
+curk
+erfnq
+erlrvronjfktdrxpnxo
+exwidxzfummwmnanz
+ialio
+loxlm
+lsaxyssmkp
+mcbvbd
+owvqa
+rcdctdyhuini
+rnbr
+ryievx
+uhsrzg
+ulndz
+vaipnem
+wots
+xsgd
+
 NATURAL:
 algorand
 algos
+alice
 apps
 barabonkov
 blockchain

--- a/.dict.fileids.json
+++ b/.dict.fileids.json
@@ -19,5 +19,8 @@
   ],
   "67f25772-2185-11ed-b830-e4b318472d90": [
     "setup.py"
+  ],
+  "13ba44e0-4a6f-11ed-9e9b-e4b318472d90": [
+    "tests/test_entities.py"
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
           export SANDBOX_DIR=$(pwd)/../sandbox
           export INITIAL_FUNDS_ACCOUNT=$(../sandbox/sandbox goal account list | awk '{print $3}' | head -n 1)          
 
+      - name: Test AlgoPytest Base Unittests
+        run: |
+          coverage run --source=algopytest -m pytest ./tests/ -v --color=yes
+
       - name: Test Algo-Recurring-Payments Unittests
         run: |
           # Unset the `INITIAL_FUNDS_ACCOUNT` to test the automatic account resolution
@@ -74,7 +78,7 @@ jobs:
 
           # So that algo-recurring-payments can be imported by the tests
           export PYTHONPATH=$(pwd)/demos/algo-recurring-payments/assets
-          coverage run --source=algopytest -m pytest ./demos/algo-recurring-payments/ -v --color=yes
+          coverage run --append --source=algopytest -m pytest ./demos/algo-recurring-payments/ -v --color=yes
 
           # Reset the `INITIAL_FUNDS_ACCOUNT`
           export INITIAL_FUNDS_ACCOUNT=$_INITIAL_FUNDS_ACCOUNT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ straightforward as possible.
 - Support multi-signature transaction with the ``multisig_transaction`` transaction operation.
 - Implemented a ``SmartContractAccount`` entity to hold the address of a smart contract as an ``AlgoUser``.
 - Utilize the ``KMD`` to access account private keys of the sandbox.
+- AlgoPytest user entities implement a ``name`` field for a more human-friendly debugging and logging experience
 
 ### Bug Fixes
 - Removed typing subscripts to be compatible with Python 3.8

--- a/algopytest/account_ops.py
+++ b/algopytest/account_ops.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import algosdk
 
 from .client_ops import _initial_funds_account
@@ -6,10 +8,10 @@ from .transaction_ops import payment_transaction
 
 
 ## CREATING
-def add_standalone_account(funded: bool = True) -> AlgoUser:
+def add_standalone_account(funded: bool = True, name: Optional[str] = None) -> AlgoUser:
     """Create standalone account and return two-tuple of its private key and address."""
     private_key, address = algosdk.account.generate_account()
-    account = AlgoUser(address, private_key)
+    account = AlgoUser(address, private_key, name)
 
     if funded:
         fund_account(account)

--- a/algopytest/entities.py
+++ b/algopytest/entities.py
@@ -75,7 +75,7 @@ class MultisigAccount(AlgoUser):
 
     def __str__(self) -> str:
         if self.name:
-            str_identifier = self.name
+            str_identifier = f"'{self.name}'"
         else:
             str_identifier = ", ".join([str(owner) for owner in self._owner_accounts])
         return f"MultisigAccount({str_identifier})"

--- a/algopytest/entities.py
+++ b/algopytest/entities.py
@@ -11,6 +11,14 @@ class AlgoUser:
 
     address: str
     private_key: Optional[str] = None
+    name: Optional[str] = None
+
+    def __str__(self) -> str:
+        str_identifier = self.name if self.name else self.address
+        return f"AlgoUser({repr(str_identifier)})"
+
+    def __repr__(self) -> str:
+        return f"AlgoUser(address={repr(self.address)}, private_key={repr(self.private_key)}, name={repr(self.name)})"
 
 
 _NullUser = AlgoUser(address="")
@@ -19,24 +27,41 @@ _NullUser = AlgoUser(address="")
 class SmartContractAccount(AlgoUser):
     """An Algorand user subclass representing a smart contract's account address."""
 
-    def __init__(self, app_id: int):
+    def __init__(self, app_id: int, name: Optional[str] = None):
+        self._app_id = app_id
+
         smart_contract_address = algosdk.logic.get_application_address(app_id)
 
         # Instantiate the super `AlgoUser` class
-        super().__init__(address=smart_contract_address)
+        super().__init__(address=smart_contract_address, name=name)
+
+    def __str__(self) -> str:
+        str_identifier = self.name if self.name else self.address
+        return f"SmartContractAccount({repr(str_identifier)})"
+
+    def __repr__(self) -> str:
+        return (
+            f"SmartContractAccount(app_id={repr(self._app_id)}, name={repr(self.name)})"
+        )
 
 
 class MultisigAccount(AlgoUser):
     """An Algorand user subclass representing a multi-signature account."""
 
-    def __init__(self, version: int, threshold: int, owner_accounts: List[AlgoUser]):
+    def __init__(
+        self,
+        version: int,
+        threshold: int,
+        owner_accounts: List[AlgoUser],
+        name: Optional[str] = None,
+    ):
         # Save the passed in values privately
         self._version = version
         self._threshold = threshold
         self._owner_accounts = owner_accounts
 
         # Instantiate the super `AlgoUser` class
-        super().__init__(address=self.attributes.address())
+        super().__init__(address=self.attributes.address(), name=name)
 
     @property
     def attributes(self) -> algosdk_transaction.Multisig:
@@ -47,3 +72,13 @@ class MultisigAccount(AlgoUser):
         return algosdk_transaction.Multisig(
             self._version, self._threshold, owners_pub_keys
         )
+
+    def __str__(self) -> str:
+        if self.name:
+            str_identifier = self.name
+        else:
+            str_identifier = ", ".join([str(owner) for owner in self._owner_accounts])
+        return f"MultisigAccount({str_identifier})"
+
+    def __repr__(self) -> str:
+        return f"MultisigAccount(version={repr(self._version)}, threshold={repr(self._threshold)}, owner_accounts={repr(self._owner_accounts)}, name={repr(self.name)})"

--- a/algopytest/fixtures.py
+++ b/algopytest/fixtures.py
@@ -1,7 +1,7 @@
 # So that sphinx picks up on the type aliases
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Optional
 
 import pytest
 from pyteal import Mode
@@ -25,7 +25,7 @@ def owner() -> YieldFixture[AlgoUser]:
     ------
     AlgoUser
     """
-    owner = add_standalone_account()
+    owner = add_standalone_account(name="owner")
 
     yield owner
 
@@ -43,7 +43,7 @@ def user1() -> YieldFixture[AlgoUser]:
     ------
     AlgoUser
     """
-    user = add_standalone_account()
+    user = add_standalone_account(name="user1")
 
     yield user
 
@@ -61,7 +61,7 @@ def user2() -> YieldFixture[AlgoUser]:
     ------
     AlgoUser
     """
-    user = add_standalone_account()
+    user = add_standalone_account(name="user2")
 
     yield user
 
@@ -79,7 +79,7 @@ def user3() -> YieldFixture[AlgoUser]:
     ------
     AlgoUser
     """
-    user = add_standalone_account()
+    user = add_standalone_account(name="user3")
 
     yield user
 
@@ -97,7 +97,7 @@ def user4() -> YieldFixture[AlgoUser]:
     ------
     AlgoUser
     """
-    user = add_standalone_account()
+    user = add_standalone_account(name="user4")
 
     yield user
 
@@ -133,8 +133,8 @@ def create_user() -> YieldFixture[Callable]:
     """
     created_users = []
 
-    def _create_user(funded: bool = True) -> AlgoUser:
-        user = add_standalone_account(funded=funded)
+    def _create_user(funded: bool = True, name: Optional[str] = None) -> AlgoUser:
+        user = add_standalone_account(funded=funded, name=name)
         created_users.append(user)
         return user
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 exclude = demos
+exclude = tests
 
 # Force all functions to be typed
 disallow_untyped_defs = True

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,85 @@
+import pytest
+
+from algopytest import AlgoUser, MultisigAccount, SmartContractAccount
+
+ADDR1 = "ERLRVRONJFKTDRXPNXO6DIX6R3BPVGQ7EXWIDXZFUMMWMNANZ2FC5I5UTQ"
+PRIV_KEY1 = "jqjLb87XuQK71/u9Lac9eKJWUhsrzgWv5wots9xeZPgkVxrFzUlVMcbvbd3hov6OwvqaHyXsgd8loxlmNA3Oig=="
+ADDR2 = "VAIPNEM5XL2RCDCTDYHUINI7RYIEVX46ULNDZ2DV7GIK5LSAXYSSMKP2GU"
+PRIV_KEY2 = "gCB2O/DWNqFvPCX/NIGH8ljxOx7Wo4hQhJLeC0iIalioEPaRnbr1EQxTHg9ENR+OEErfnqLaPOh1+ZCurkC+JQ=="
+
+
+@pytest.fixture
+def algouser_alice():
+    return AlgoUser(ADDR1, PRIV_KEY1, "Alice")
+
+
+@pytest.fixture
+def algouser_bob():
+    return AlgoUser(ADDR2, PRIV_KEY2, "Bob")
+
+
+@pytest.fixture
+def smart_contract_account():
+    return SmartContractAccount(42, "Answer to the Universe")
+
+
+@pytest.fixture
+def multisig_account(algouser_alice, algouser_bob):
+    return MultisigAccount(
+        version=1,
+        threshold=1,
+        owner_accounts=[algouser_alice, algouser_bob],
+        name="Family Account",
+    )
+
+
+@pytest.fixture
+def multisig_account_no_name(algouser_alice, algouser_bob):
+    return MultisigAccount(
+        version=1,
+        threshold=1,
+        owner_accounts=[algouser_alice, algouser_bob],
+    )
+
+
+@pytest.mark.parametrize(
+    "entity_name, expected",
+    [
+        ("algouser_alice", "AlgoUser('Alice')"),
+        ("smart_contract_account", "SmartContractAccount('Answer to the Universe')"),
+        ("multisig_account", "MultisigAccount('Family Account')"),
+        (
+            "multisig_account_no_name",
+            "MultisigAccount(AlgoUser('Alice'), AlgoUser('Bob'))",
+        ),
+    ],
+)
+def test_entity_str_method(entity_name, expected, request):
+    entity = request.getfixturevalue(entity_name)
+    assert str(entity) == expected
+
+
+@pytest.mark.parametrize(
+    "entity_name, expected",
+    [
+        (
+            "algouser_alice",
+            f"AlgoUser(address='{ADDR1}', private_key='{PRIV_KEY1}', name='Alice')",
+        ),
+        (
+            "smart_contract_account",
+            "SmartContractAccount(app_id=42, name='Answer to the Universe')",
+        ),
+        (
+            "multisig_account",
+            f"MultisigAccount(version=1, threshold=1, owner_accounts=[AlgoUser(address='{ADDR1}', private_key='{PRIV_KEY1}', name='Alice'), AlgoUser(address='{ADDR2}', private_key='{PRIV_KEY2}', name='Bob')], name='Family Account')",
+        ),
+        (
+            "multisig_account_no_name",
+            f"MultisigAccount(version=1, threshold=1, owner_accounts=[AlgoUser(address='{ADDR1}', private_key='{PRIV_KEY1}', name='Alice'), AlgoUser(address='{ADDR2}', private_key='{PRIV_KEY2}', name='Bob')], name=None)",
+        ),
+    ],
+)
+def test_entity_repr_method(entity_name, expected, request):
+    entity = request.getfixturevalue(entity_name)
+    assert repr(entity) == expected


### PR DESCRIPTION
To make logging and debugging simpler, the Algorand user entities such as the `AlgoUser` now take an optional string `name` field. This `name` is used by the `__str__` function to a more user-friendly output.

Fixes #31 

---

### Checklist

- [x] Added a CHANGELOG entry
- [X] Tested locally
- [x] Wrote new tests
- [ ] Added new dependencies
- [ ] Updated the documentation