### PR TITLE
Function `smart_signature_transaction` accepts transaction tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ straightforward as possible.
 - All transaction operations take all possible parameters, even the less commonly used ones.
 - The AlgoPytest API accepts ``AlgoUser`` as a user input anywhere whenever an address is requested.
 - Sped up the ``AlgoPytest`` test suite runtime by caching the ``_initial_funds_account``.
+- Altered arguments of ``smart_signature_transaction`` to accept transaction tuple
 
 ## [1.0.0] - 2022-02-09
 

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -994,12 +994,12 @@ def close_out_asset(
 )
 def smart_signature_transaction(
     smart_signature: bytes,
-    txn: algosdk_transaction.Transaction,
+    txn: Tuple[AlgoUser, algosdk_transaction.Transaction],
     *,
     params: Optional[algosdk_transaction.SuggestedParams],
 ) -> Tuple[AlgoUser, algosdk_transaction.LogicSigTransaction]:
     """Write docs here: TODO!"""
-    logic_txn = algosdk_transaction.LogicSigTransaction(txn, smart_signature)
+    logic_txn = algosdk_transaction.LogicSigTransaction(txn[1], smart_signature)
     return _NullUser, logic_txn
 
 

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -994,12 +994,12 @@ def close_out_asset(
 )
 def smart_signature_transaction(
     smart_signature: bytes,
-    txn: Tuple[AlgoUser, algosdk_transaction.Transaction],
+    transaction: Tuple[AlgoUser, algosdk_transaction.Transaction],
     *,
     params: Optional[algosdk_transaction.SuggestedParams],
 ) -> Tuple[AlgoUser, algosdk_transaction.LogicSigTransaction]:
     """Write docs here: TODO!"""
-    logic_txn = algosdk_transaction.LogicSigTransaction(txn[1], smart_signature)
+    logic_txn = algosdk_transaction.LogicSigTransaction(transaction[1], smart_signature)
     return _NullUser, logic_txn
 
 


### PR DESCRIPTION
This PR alters the API of `smart_signature_transaction` to accept the entire transaction tuple instead of only the transaction. This makes the usage much cleaner for the developer when writing tests.

Resolves #53

---

### Checklist

- [x] Added a CHANGELOG entry
- [x] Tested locally
- [ ] Wrote new tests
- [ ] Added new dependencies
- [ ] Updated the documentation