### PR TITLE
Add type checking to `transaction_boilerplate`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: 22.8.0
     hooks:
     - id: black
-      language_version: python3.10
+      language_version: python3
 -   repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:

--- a/algopytest/client_ops.py
+++ b/algopytest/client_ops.py
@@ -5,16 +5,9 @@ Module containing helper functions for accessing Algorand blockchain.
 from __future__ import annotations
 
 import base64
-import sys
 import time
 from functools import lru_cache, wraps
-from typing import Any, Callable, Dict, Optional, TypeVar
-
-# The `ParamSpec` does not have native support before Python v3.10
-if sys.version_info < (3, 10):
-    from typing_extensions import ParamSpec
-else:
-    from typing import ParamSpec
+from typing import Any, Callable, Dict, Optional
 
 import pyteal
 from algosdk import mnemonic
@@ -27,10 +20,8 @@ from pyteal import Mode, compileTeal
 
 from .config_params import ConfigParams
 from .entities import AlgoUser
+from .type_stubs import P, T
 from .utils import _convert_algo_dict
-
-P = ParamSpec("P")
-T = TypeVar("T")
 
 
 ## CLIENTS

--- a/algopytest/client_ops.py
+++ b/algopytest/client_ops.py
@@ -20,7 +20,7 @@ from pyteal import Mode, compileTeal
 
 from .config_params import ConfigParams
 from .entities import AlgoUser
-from .type_stubs import P, T
+from .type_stubs import P, T, TransactionT
 from .utils import _convert_algo_dict
 
 
@@ -66,7 +66,7 @@ def _get_kmd_account_private_key(address: str) -> str:
 
 
 ## TRANSACTIONS
-def process_transactions(transactions: list[algosdk_transaction.Transaction]) -> int:
+def process_transactions(transactions: list[TransactionT]) -> int:
     """Send provided grouped ``transactions`` to network and wait for confirmation."""
     client = _algod_client()
     transaction_id = client.send_transactions(transactions)

--- a/algopytest/smart_program_ops.py
+++ b/algopytest/smart_program_ops.py
@@ -40,12 +40,12 @@ def deploy_smart_contract(
     global_bytes: int = 0,
     *,
     app_args: Optional[List[Union[str, int]]] = None,
-    accounts: Optional[List[str]] = None,
+    accounts: Optional[List[AlgoUser]] = None,
     foreign_apps: Optional[List[int]] = None,
     foreign_assets: Optional[List[int]] = None,
     note: str = "",
     lease: str = "",
-    rekey_to: str = "",
+    rekey_to: Optional[AlgoUser] = None,
     extra_pages: int = 0,
 ) -> DeployedSmartContract:
     approval_compiled = compile_program(approval_program, Mode.Application, version)

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from functools import wraps
 from types import TracebackType

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -45,6 +45,8 @@ class TxnIDContext:
         _with_txn_id = None
 
 
+# TODO!!! Replace Tuple[AlgoUser, Any] with something more representable of what the transaction ops return
+# even though in end effect, it will be the same. It will look cleaner in this code.
 def transaction_boilerplate(
     no_log: bool = False,
     no_params: bool = False,

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -1,10 +1,12 @@
 from functools import wraps
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, ParamSpec, Tuple, Union
 
 from algosdk.future import transaction as algosdk_transaction
 
 from .client_ops import pending_transaction_info, process_transactions, suggested_params
 from .entities import AlgoUser, MultisigAccount, _NullUser
+
+P = ParamSpec("P")
 
 # Global variable switches controlled by context managers for the `transaction_boilerplate` decorator
 _no_log: Optional[bool] = None
@@ -52,14 +54,14 @@ def transaction_boilerplate(
     with_txn_id: bool = False,
     format_finish: Optional[Callable] = None,
     return_fn: Optional[Callable] = None,
-) -> Callable:
+) -> Callable[[Callable[P, Tuple[AlgoUser, Any]]], Callable[P, Any]]:
     """A decorator to handle all of the transaction boilerplate."""
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[P, Tuple[AlgoUser, Any]]) -> Callable[P, Any]:
         """The actual decorator since it takes the arguments above."""
 
         @wraps(func)
-        def wrapped(*args: Any, **kwargs: Any) -> Any:
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> Any:
             # Apply the global modifiers if any are set
             f_no_log = no_log if _no_log is None else _no_log
             f_no_params = no_params if _no_params is None else _no_params
@@ -141,7 +143,7 @@ def create_app(
     global_schema: algosdk_transaction.StateSchema,
     local_schema: algosdk_transaction.StateSchema,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     app_args: Optional[List[Union[str, int]]] = None,
     accounts: Optional[List[AlgoUser]] = None,
     foreign_apps: Optional[List[int]] = None,
@@ -230,7 +232,7 @@ def delete_app(
     owner: AlgoUser,
     app_id: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     app_args: Optional[List[Union[str, int]]] = None,
     accounts: Optional[List[AlgoUser]] = None,
     foreign_apps: Optional[List[int]] = None,
@@ -301,7 +303,7 @@ def update_app(
     approval_compiled: bytes,
     clear_compiled: bytes,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     app_args: Optional[List[Union[str, int]]] = None,
     accounts: Optional[List[AlgoUser]] = None,
     foreign_apps: Optional[List[int]] = None,
@@ -377,7 +379,7 @@ def opt_in_app(
     sender: AlgoUser,
     app_id: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     app_args: Optional[List[Union[str, int]]] = None,
     accounts: Optional[List[AlgoUser]] = None,
     foreign_apps: Optional[List[int]] = None,
@@ -446,7 +448,7 @@ def close_out_app(
     sender: AlgoUser,
     app_id: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     app_args: Optional[List[Union[str, int]]] = None,
     accounts: Optional[List[AlgoUser]] = None,
     foreign_apps: Optional[List[int]] = None,
@@ -515,7 +517,7 @@ def clear_app(
     sender: AlgoUser,
     app_id: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     app_args: Optional[List[Union[str, int]]] = None,
     accounts: Optional[List[AlgoUser]] = None,
     foreign_apps: Optional[List[int]] = None,
@@ -584,7 +586,7 @@ def call_app(
     sender: AlgoUser,
     app_id: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     app_args: Optional[List[Union[str, int]]] = None,
     accounts: Optional[List[AlgoUser]] = None,
     foreign_apps: Optional[List[int]] = None,
@@ -652,7 +654,7 @@ def payment_transaction(
     receiver: AlgoUser,
     amount: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     close_remainder_to: Optional[AlgoUser] = None,
     note: str = "",
     lease: str = "",
@@ -717,7 +719,7 @@ def create_asset(
     unit_name: str,
     default_frozen: bool,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     url: str = "",
     metadata_hash: str = "",
     note: str = "",
@@ -763,7 +765,7 @@ def destroy_asset(
     sender: AlgoUser,
     asset_id: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     note: str = "",
     lease: str = "",
     rekey_to: Optional[AlgoUser] = None,
@@ -797,11 +799,11 @@ def update_asset(
     sender: AlgoUser,
     asset_id: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
     manager: Optional[AlgoUser],
     reserve: Optional[AlgoUser],
     freeze: Optional[AlgoUser],
     clawback: Optional[AlgoUser],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     note: str = "",
     lease: str = "",
     rekey_to: Optional[AlgoUser] = None,
@@ -846,7 +848,7 @@ def freeze_asset(
     new_freeze_state: bool,
     asset_id: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     note: str = "",
     lease: str = "",
     rekey_to: Optional[AlgoUser] = None,
@@ -884,7 +886,7 @@ def transfer_asset(
     amount: int,
     asset_id: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     close_assets_to: Optional[AlgoUser] = None,
     revocation_target: Optional[AlgoUser] = None,
     note: str = "",
@@ -926,7 +928,7 @@ def opt_in_asset(
     sender: AlgoUser,
     asset_id: int,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     note: str = "",
     lease: str = "",
     rekey_to: Optional[AlgoUser] = None,
@@ -961,7 +963,7 @@ def close_out_asset(
     asset_id: int,
     receiver: AlgoUser,
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
     note: str = "",
     lease: str = "",
     rekey_to: Optional[AlgoUser] = None,
@@ -996,7 +998,7 @@ def smart_signature_transaction(
     smart_signature: bytes,
     transaction: Tuple[AlgoUser, algosdk_transaction.Transaction],
     *,
-    params: Optional[algosdk_transaction.SuggestedParams],
+    params: Optional[algosdk_transaction.SuggestedParams] = None,
 ) -> Tuple[AlgoUser, algosdk_transaction.LogicSigTransaction]:
     """Write docs here: TODO!"""
     logic_txn = algosdk_transaction.LogicSigTransaction(transaction[1], smart_signature)

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -1,12 +1,11 @@
 from functools import wraps
-from typing import Any, Callable, List, Optional, ParamSpec, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 from algosdk.future import transaction as algosdk_transaction
 
 from .client_ops import pending_transaction_info, process_transactions, suggested_params
 from .entities import AlgoUser, MultisigAccount, _NullUser
-
-P = ParamSpec("P")
+from .type_stubs import P
 
 # Global variable switches controlled by context managers for the `transaction_boilerplate` decorator
 _no_log: Optional[bool] = None

--- a/algopytest/type_stubs.py
+++ b/algopytest/type_stubs.py
@@ -1,5 +1,14 @@
+import sys
 from typing import Generator, TypeVar
 
-# Type for PyTest fixtures which yield a fixture themselves
+# The `ParamSpec` does not have native support before Python v3.10
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
+
+P = ParamSpec("P")
 T = TypeVar("T")
+
+# Type for PyTest fixtures which yield a fixture themselves
 YieldFixture = Generator[T, None, None]

--- a/algopytest/type_stubs.py
+++ b/algopytest/type_stubs.py
@@ -1,5 +1,7 @@
 import sys
-from typing import Generator, TypeVar
+from typing import TYPE_CHECKING, Generator, TypeVar, Union
+
+from algosdk.future import transaction as algosdk_transaction
 
 # The `ParamSpec` does not have native support before Python v3.10
 if sys.version_info < (3, 10):
@@ -7,8 +9,18 @@ if sys.version_info < (3, 10):
 else:
     from typing import ParamSpec
 
+if TYPE_CHECKING:
+    from .transaction_ops import _GroupTxn, _MultisigTxn
+
 P = ParamSpec("P")
 T = TypeVar("T")
 
 # Type for PyTest fixtures which yield a fixture themselves
 YieldFixture = Generator[T, None, None]
+
+TransactionT = Union[
+    algosdk_transaction.Transaction,
+    algosdk_transaction.LogicSigTransaction,
+    "_MultisigTxn",
+    "_GroupTxn",
+]


### PR DESCRIPTION
Utilize the `ParamSpec` to actually type check the `transaction_boilerplate` decorator.
Fixes #56

---

### Checklist

- [ ] Added a CHANGELOG entry
- [ ] Tested locally
- [ ] Wrote new tests
- [ ] Added new dependencies
- [ ] Updated the documentation