### PR TITLE
Made `create_asset` into a context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ straightforward as possible.
 - Implemented a ``TxnElemsContext`` context manager which alters all transaction operations to return an unsent transaction object rather than send the transaction.
 - Implemented a ``TxnIDContext`` context manager which alters all transaction operations to return the ``txn_id`` associated with the sent transaction.
 - Functions ``create_app`` and ``create_compiled_app`` are int sub-classed context managers that may be used in a ``with`` clause or cleaned up manually with ``delete_app``.
+- Function ``create_asset`` returns an int sub-classed context manager that can handle clean up within a ``with`` clause.
 
 ### Bug Fixes
 - Removed typing subscripts to be compatible with Python 3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ straightforward as possible.
 - AlgoPytest user entities implement a ``name`` field for a more human-friendly debugging and logging experience
 - Implemented a ``TxnElemsContext`` context manager which alters all transaction operations to return an unsent transaction object rather than send the transaction.
 - Implemented a ``TxnIDContext`` context manager which alters all transaction operations to return the ``txn_id`` associated with the sent transaction.
-- Functions ``create_app`` and ``create_compiled_app`` are int sub-classed context managers that may be used in a ``with`` clause or cleaned up manually with ``destroy_app``.
+- Functions ``create_app`` and ``create_compiled_app`` are int sub-classed context managers that may be used in a ``with`` clause or cleaned up manually with ``delete_app``.
 
 ### Bug Fixes
 - Removed typing subscripts to be compatible with Python 3.8

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -93,11 +93,11 @@ class DeployedAppID(int):
 class DeployedAssetID(int):
     """Subclass the `int` so that it can be used as a context manager or directly."""
 
-    owner: AlgoUser
+    sender: AlgoUser
 
-    def __new__(cls, asset_id: int, owner: AlgoUser):
+    def __new__(cls, asset_id: int, sender: AlgoUser):
         _asset_id = int.__new__(cls, asset_id)
-        _asset_id.owner = owner
+        _asset_id.sender = sender
         return _asset_id
 
     def __enter__(self) -> int:
@@ -109,7 +109,7 @@ class DeployedAssetID(int):
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> typing_extensions.Literal[False]:
-        destroy_asset(self.owner, asset_id=self)
+        destroy_asset(self.sender, asset_id=self)
         return False
 
 

--- a/algopytest/transaction_ops.py
+++ b/algopytest/transaction_ops.py
@@ -93,11 +93,11 @@ class DeployedAppID(int):
 class DeployedAssetID(int):
     """Subclass the `int` so that it can be used as a context manager or directly."""
 
-    sender: AlgoUser
+    owner: AlgoUser
 
-    def __new__(cls, asset_id: int, sender: AlgoUser):
+    def __new__(cls, asset_id: int, owner: AlgoUser):
         _asset_id = int.__new__(cls, asset_id)
-        _asset_id.sender = sender
+        _asset_id.owner = owner
         return _asset_id
 
     def __enter__(self) -> int:
@@ -109,7 +109,7 @@ class DeployedAssetID(int):
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> typing_extensions.Literal[False]:
-        destroy_asset(self.sender, asset_id=self)
+        destroy_asset(self.owner, asset_id=self)
         return False
 
 


### PR DESCRIPTION
Made `create_asset` return an int sub-classed context manager that can be used within a `with` clause to automatically handle its clean up. It also can be cleaned up manually using `destroy_asset` on the `asset_id`.

---

### Checklist

- [x] Added a CHANGELOG entry
- [X] Tested locally
- [X] Wrote new tests
- [ ] Added new dependencies
- [ ] Updated the documentation