### PR TITLE
Removed upper-bound pin on pyteal in the environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,5 +15,5 @@ dependencies:
   - typing_extensions
   - pip:
     - py-algorand-sdk
-    - pyteal<=0.13.0
+    - pyteal
     - scspell3k


### PR DESCRIPTION
The latest release of `pyteal` no longer interferes with `py-algorand-sdk=v2.0.0`. So the upper-bound pin may be removed.

Fixes #68 

---

### Checklist

- [ ] Added a CHANGELOG entry
- [ ] Tested locally
- [ ] Wrote new tests
- [ ] Added new dependencies
- [ ] Updated the documentation