### PR TITLE
Removed search link from index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ straightforward as possible.
 - Introduced the type alias ``SignerTxnPairT`` to make the output of transaction operations less confusing.
 - Divided the API documentation into subsections for easier referencing.
 - Replaced ``mdash`` html code in README.md with UTF8 mdash so that sphinx displays it correctly
+- Removed non-working search and index links at the bottom of the sphinx index page.
 
 ## [1.0.0] - 2022-02-09
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,9 +16,3 @@ Welcome to AlgoPytest's documentation!
    demos
 
 .. mdinclude:: ../../README.md
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`search`


### PR DESCRIPTION
There were search and index links at the bottom pages. Though with good intentions, they do not seem to work correctly and provide marginal added benefit. Simply removing them seems to be good enough.
Fixes #41

---

### Checklist

- [X] Added a CHANGELOG entry
- [ ] Tested locally
- [ ] Wrote new tests
- [ ] Added new dependencies
- [X] Updated the documentation